### PR TITLE
GOptionContext* context not freed.

### DIFF
--- a/gnome-thumbnailer-skeleton.c
+++ b/gnome-thumbnailer-skeleton.c
@@ -250,10 +250,13 @@ int main (int argc, char **argv)
 	g_option_context_add_main_entries (context, entries, NULL);
 
 	if (g_option_context_parse (context, &argc, &argv, &error) == FALSE) {
+		g_option_context_free (context);
 		g_warning ("Couldn't parse command-line options: %s", error->message);
 		g_error_free (error);
 		return 1;
 	}
+
+	g_option_context_free (context);
 
 	/* Set fatal warnings if required */
 	if (g_fatal_warnings) {


### PR DESCRIPTION
According with glib documentation,
https://docs.gtk.org/glib/type_func.OptionContext.new.html, a new
GOptionContext must be freed with g_option_context_free() after use.